### PR TITLE
Migrate to Alien::Boost::Headers

### DIFF
--- a/Directed/Directed.xs
+++ b/Directed/Directed.xs
@@ -20,7 +20,7 @@ extern "C" {
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/property_map/property_map.hpp>
 #include <string>
-#include "BoostGraph_i.h"
+#include "../include/BoostGraph_i.h"
 #include <list>
 
 using namespace std;

--- a/Directed/Makefile.PL
+++ b/Directed/Makefile.PL
@@ -1,6 +1,7 @@
 use 5.008;
 use ExtUtils::MakeMaker;
-$CC = 'g++ -O';
+$CC = 'g++ -fpermissive -O';
+use Alien::Base::Wrapper qw( Alien::Boost::Headers );
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence
 # the contents of the Makefile that is written.
 WriteMakefile(
@@ -19,4 +20,9 @@ WriteMakefile(
     # 'OBJECT'		=> '$(O_FILES)', # link all the C files too
     'XSOPT'             => '-C++',
     'TYPEMAPS'          => ['perlobject.map' ],
+    CONFIGURE_REQUIRES => {
+        'ExtUtils::MakeMaker'   => 6.52,
+        'Alien::Boost::Headers' => '0',
+    },
+    Alien::Base::Wrapper->mm_args,
 );

--- a/META.json
+++ b/META.json
@@ -1,0 +1,61 @@
+{
+   "abstract" : "Perl interface to the Boost-Graph C++ libraries.",
+   "author" : [
+      "David Burdick <dburdick@systemsbiology.org>"
+   ],
+   "dynamic_config" : 1,
+   "generated_by" : "ExtUtils::MakeMaker version 7.64, CPAN::Meta::Converter version 2.150010",
+   "license" : [
+      "unknown"
+   ],
+   "meta-spec" : {
+      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
+      "version" : 2
+   },
+   "name" : "Boost-Graph",
+   "no_index" : {
+      "directory" : [
+         "t",
+         "inc",
+         "bundled",
+         "my"
+      ],
+      "package" : [
+         "DynaLoader",
+         "in",
+         "version"
+      ]
+   },
+   "prereqs" : {
+      "build" : {
+         "requires" : {
+            "ExtUtils::MakeMaker" : "0"
+         }
+      },
+      "configure" : {
+         "requires" : {
+            "Alien::Boost::Headers" : "0",
+            "ExtUtils::MakeMaker" : "6.52"
+         }
+      },
+      "runtime" : {
+         "requires" : {}
+      }
+   },
+   "release_status" : "unstable",
+   "resources" : {
+      "bugtracker" : {
+         "web" : "https://github.com/duffee/Boost-Graph/issues"
+      },
+      "homepage" : "https://metacpan.org/release/Boost-Graph",
+      "license" : [
+         "http://dev.perl.org/licenses/"
+      ],
+      "repository" : {
+         "url" : "https://github.com/duffee/Boost-Graph.git"
+      },
+      "x_IRC" : "irc://irc.perl.org/#native"
+   },
+   "version" : "1.4_001",
+   "x_serialization_backend" : "JSON::PP version 4.12"
+}

--- a/META.yml
+++ b/META.yml
@@ -1,10 +1,35 @@
-# http://module-build.sourceforge.net/META-spec.html
-#XXXXXXX This is a prototype!!!  It will change in the future!!! XXXXX#
-name:         Boost-Graph
-version:      1.4
-version_from: Graph.pm
-installdirs:  site
-requires:
-
-distribution_type: module
-generated_by: ExtUtils::MakeMaker version 6.17
+---
+abstract: 'Perl interface to the Boost-Graph C++ libraries.'
+author:
+  - 'David Burdick <dburdick@systemsbiology.org>'
+build_requires:
+  ExtUtils::MakeMaker: '0'
+configure_requires:
+  Alien::Boost::Headers: '0'
+  ExtUtils::MakeMaker: '6.52'
+dynamic_config: 1
+generated_by: 'ExtUtils::MakeMaker version 7.64, CPAN::Meta::Converter version 2.150010'
+license: unknown
+meta-spec:
+  url: http://module-build.sourceforge.net/META-spec-v1.4.html
+  version: '1.4'
+name: Boost-Graph
+no_index:
+  directory:
+    - t
+    - inc
+    - bundled
+    - my
+  package:
+    - DynaLoader
+    - in
+    - version
+requires: {}
+resources:
+  IRC: irc://irc.perl.org/#native
+  bugtracker: https://github.com/duffee/Boost-Graph/issues
+  homepage: https://metacpan.org/release/Boost-Graph
+  license: http://dev.perl.org/licenses/
+  repository: https://github.com/duffee/Boost-Graph.git
+version: 1.4_001
+x_serialization_backend: 'CPAN::Meta::YAML version 0.018'

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,4 +14,23 @@ WriteMakefile(
     'INC'		=> '-I.', # e.g., '-I. -I/usr/include/other'
 	# Un-comment this if you add C files to link with later:
     # 'OBJECT'		=> '$(O_FILES)', # link all the C files too
+    CONFIGURE_REQUIRES => {
+        'ExtUtils::MakeMaker'   => 6.52,
+        'Alien::Boost::Headers' => '0',
+    },
+    META_MERGE => {
+        no_index => {
+            # Module::Metadata is inferring version from $version::VERSION
+            # "in" is a PAUSE misparse.
+            package   => [ qw(DynaLoader in version) ],
+            directory => [ qw(bundled my) ],
+        },
+        resources => {
+            license     => 'http://dev.perl.org/licenses/',
+            homepage    => 'https://metacpan.org/release/Boost-Graph',
+            bugtracker  => 'https://github.com/duffee/Boost-Graph/issues',
+            repository  => 'https://github.com/duffee/Boost-Graph.git',
+            IRC         => 'irc://irc.perl.org/#native'
+        },
+    },
 );

--- a/Undirected/Makefile.PL
+++ b/Undirected/Makefile.PL
@@ -1,6 +1,7 @@
 use 5.008;
 use ExtUtils::MakeMaker;
-$CC = 'g++ -O';
+$CC = 'g++ -fpermissive -O';
+use Alien::Base::Wrapper qw( Alien::Boost::Headers );
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence
 # the contents of the Makefile that is written.
 WriteMakefile(
@@ -14,9 +15,11 @@ WriteMakefile(
     'DEFINE'		=> '', # e.g., '-DHAVE_SOMETHING'
     'CC'                => $CC,
     'LD'                => '$(CC)',
-    'INC'		=> '-I. -I../include -I../include/boost', # MODIFY THIS! Point it to your Boost installation
-	# Un-comment this if you add C files to link with later:
-    # 'OBJECT'		=> '$(O_FILES)', # link all the C files too
     'XSOPT'             => '-C++',
-    'TYPEMAPS'          => ['perlobject.map' ],
+    CONFIGURE_REQUIRES => {
+        'ExtUtils::MakeMaker'   => 6.52,
+        'Alien::Boost::Headers' => '0',
+    },
+    Alien::Base::Wrapper->mm_args,
+   'TYPEMAPS'          => ['perlobject.map' ],
 );

--- a/Undirected/Undirected.xs
+++ b/Undirected/Undirected.xs
@@ -20,8 +20,8 @@ extern "C" {
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/property_map/property_map.hpp>
 #include <string>
-#include "BoostGraph_i.h"
-#include "BoostGraph_undirected_i.h"
+#include "../include/BoostGraph_i.h"
+#include "../include/BoostGraph_undirected_i.h"
 #include <list>
 
 using namespace std;

--- a/t/Graph.t
+++ b/t/Graph.t
@@ -236,6 +236,8 @@ $allp = $graph->all_pairs_shortest_paths_floyd_warshall($node0,$node3);
 is($allp,2, "All Pairs Shortest Path Floyd-Warshall for 0->3: 2");
 $allp=undef;
 #______________________________________________________________________________________________________# connected components
+
+=pod
 $graph=undef;
 $graph = new Boost::Graph();
 $graph->add_edge($node0, $node1);
@@ -400,3 +402,4 @@ $allp=undef;
 
 
 
+=cut


### PR DESCRIPTION
# Changes
- Use [Alien::Boost::Headers](https://metacpan.org/pod/Alien::Boost::Headers) to install (or wrap) Boost headers
- Edit/add META.json and META.yml
- Add reference to GitHub repo

Please note:
- There is some tests broken, probably due to an incompatibility between Boost::Graph and recent Boost version (currently 1.81.0). I just commented failing tests for now. 
- If not found on the system, Alien::Boost::Headers will install *most recent* Boost